### PR TITLE
Fix elli_cookie:get/2,3 specs

### DIFF
--- a/src/elli_cookie.erl
+++ b/src/elli_cookie.erl
@@ -94,10 +94,9 @@ get(Key, Cookies) -> get(Key, Cookies, undefined).
 
 %% @doc Retrieve a specific cookie value from the set of parsed cookies.
 %% If there is not a value for `Key' in `Cookies', return `Default'.
--spec get(Key, Cookies, Default) -> binary() when
+-spec get(Key, Cookies, Default) -> binary() | Default when
     Key     :: binary() | string(),
-    Cookies :: no_cookies | cookie_list(),
-    Default :: binary() | undefined.
+    Cookies :: no_cookies | cookie_list().
 get(_, no_cookies, Default) -> Default;
 get(Key, Cookies, Default) ->
   ok = valid_cookie_name(Key),

--- a/src/elli_cookie.erl
+++ b/src/elli_cookie.erl
@@ -157,7 +157,7 @@ secure() -> secure.
 http_only() -> http_only.
 
 %% @doc Set cookie expiration.
--spec expires(Expiration :: expiration()) -> expires().
+-spec expires(Expiration :: expiration() | calendar:datetime()) -> expires().
 expires({S, seconds}) -> expires_plus(S);
 expires({M, minutes}) -> expires_plus(M*60);
 expires({H, hours})   -> expires_plus(H*60*60);

--- a/src/elli_cookie.erl
+++ b/src/elli_cookie.erl
@@ -89,14 +89,14 @@ parse(Req) -> tokenize(elli_request:get_header(<<"Cookie">>, Req)).
 %% @equiv get(Key, Cookies, undefined)
 -spec get(Key, Cookies) -> binary() | undefined when
     Key     :: binary() | string(),
-    Cookies :: cookie_list().
+    Cookies :: no_cookies | cookie_list().
 get(Key, Cookies) -> get(Key, Cookies, undefined).
 
 %% @doc Retrieve a specific cookie value from the set of parsed cookies.
 %% If there is not a value for `Key' in `Cookies', return `Default'.
 -spec get(Key, Cookies, Default) -> binary() when
     Key     :: binary() | string(),
-    Cookies :: cookie_list(),
+    Cookies :: no_cookies | cookie_list(),
     Default :: binary() | undefined.
 get(_, no_cookies, Default) -> Default;
 get(Key, Cookies, Default) ->


### PR DESCRIPTION
They were missing the atom `no_cookies` that can be received instead of a `cookie_list/0`